### PR TITLE
feat: Codesign all binary-like files

### DIFF
--- a/util.js
+++ b/util.js
@@ -221,23 +221,12 @@ module.exports.walkAsync = function (dirPath) {
             .then(function (stat) {
               if (stat.isFile()) {
                 switch (path.extname(filePath)) {
-                  case '': // Binary
-                    if (path.basename(filePath)[0] !== '.') {
-                      return getFilePathIfBinaryAsync(filePath)
-                    } // Else reject hidden file
-                    break
-                  case '.dylib': // Dynamic library
-                  case '.node': // Native node addon
-                    return filePath
                   case '.cstemp': // Temporary file generated from past codesign
                     debuglog('Removing... ' + filePath)
                     return unlinkAsync(filePath)
                       .thenReturn(undefined)
                   default:
-                    if (path.extname(filePath).indexOf(' ') >= 0) {
-                      // Still consider the file as binary if extension seems invalid
-                      return getFilePathIfBinaryAsync(filePath)
-                    }
+                    return getFilePathIfBinaryAsync(filePath)
                 }
               } else if (stat.isDirectory() && !stat.isSymbolicLink()) {
                 return _walkAsync(filePath)


### PR DESCRIPTION
In the current implementation, files with names like `.node` (`.node` as the base name, not as a file extension) will be skipped while scanning the application bundle. Testing all possible binary files should help clear the naming ambiguity. Files like `.gitignore` should still be skipped.

Addresses: #168

cc: @malept 