### PR TITLE
feat: Add option to specify login helper entitlements file

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,9 +164,8 @@ See [default.entitlements.mas.inherit.plist](https://github.com/electron-userlan
 
 `entitlements-loginhelper` - *String*
 
-Path to login helper entitlement file. When using app sandboxing the inherited entitlement should not be used since this is a standalone executable. When not set, uses `entitlements-inherit` option.
-*This option only applies when signing with entitlements.*
-See [default.entitlements.mas.inherit.plist](https://github.com/electron-userland/electron-osx-sign/blob/master/default.entitlements.mas.inherit.plist) or [default.entitlements.darwin.inherit.plist](https://github.com/electron-userland/electron-osx-sign/blob/master/default.entitlements.darwin.inherit.plist) with respect to your platform.
+Path to login helper entitlement file. When using App Sandbox, the inherited entitlement should not be used since this is a standalone executable. *This option only applies when signing with entitlements.*
+Default to [default.entitlements.mas.inherit.plist](https://github.com/electron-userland/electron-osx-sign/blob/master/default.entitlements.mas.inherit.plist).
 
 `gatekeeper-assess` - *Boolean*
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,12 @@ See [default.entitlements.mas.plist](https://github.com/electron-userland/electr
 Path to child entitlements which inherit the security settings for signing frameworks and bundles of a distribution. *This option only applies when signing with entitlements.*
 See [default.entitlements.mas.inherit.plist](https://github.com/electron-userland/electron-osx-sign/blob/master/default.entitlements.mas.inherit.plist) or [default.entitlements.darwin.inherit.plist](https://github.com/electron-userland/electron-osx-sign/blob/master/default.entitlements.darwin.inherit.plist) with respect to your platform.
 
+`entitlements-loginhelper` - *String*
+
+Path to login helper entitlement file. When using app sandboxing the inherited entitlement should not be used since this is a standalone executable. When not set, uses `entitlements-inherit` option.
+*This option only applies when signing with entitlements.*
+See [default.entitlements.mas.inherit.plist](https://github.com/electron-userland/electron-osx-sign/blob/master/default.entitlements.mas.inherit.plist) or [default.entitlements.darwin.inherit.plist](https://github.com/electron-userland/electron-osx-sign/blob/master/default.entitlements.darwin.inherit.plist) with respect to your platform.
+
 `gatekeeper-assess` - *Boolean*
 
 Flag to enable/disable Gatekeeper assessment after signing the app. Disabling it is useful for signing with self-signed certificates.

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ See [default.entitlements.mas.inherit.plist](https://github.com/electron-userlan
 `entitlements-loginhelper` - *String*
 
 Path to login helper entitlement file. When using App Sandbox, the inherited entitlement should not be used since this is a standalone executable. *This option only applies when signing with entitlements.*
-Default to [default.entitlements.mas.inherit.plist](https://github.com/electron-userland/electron-osx-sign/blob/master/default.entitlements.mas.inherit.plist).
+Default to the same entitlements file used for signing the app bundle.
 
 `gatekeeper-assess` - *Boolean*
 

--- a/bin/electron-osx-sign-usage.txt
+++ b/bin/electron-osx-sign-usage.txt
@@ -22,7 +22,7 @@ DESCRIPTION
     This option only applies when signing with entitlements.
 
   --entitlements-loginhelper=file
-    Path to login helper entitlement file. When using app sandboxing the inherited entitlement should not be used since this is a standalone executable. When not set, uses `entitlements-inherit` option.
+    Path to login helper entitlement file. When using App Sandbox, the inherited entitlement should not be used since this is a standalone executable.
     This option only applies when signing with entitlements.
 
   --gatekeeper-assess, --no-gatekeeper-assess

--- a/bin/electron-osx-sign-usage.txt
+++ b/bin/electron-osx-sign-usage.txt
@@ -21,6 +21,10 @@ DESCRIPTION
     Path to child entitlements which inherit the security settings for signing frameworks and bundles of a distribution.
     This option only applies when signing with entitlements.
 
+  --entitlements-loginhelper=file
+    Path to login helper entitlement file. When using app sandboxing the inherited entitlement should not be used since this is a standalone executable. When not set, uses `entitlements-inherit` option.
+    This option only applies when signing with entitlements.
+
   --gatekeeper-assess, --no-gatekeeper-assess
     Flag to enable/disable Gatekeeper assessment after signing the app. Disabling it is useful for signing with self-signed certificates.
     Gatekeeper assessment is enabled by default on ``darwin'' platform.

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,6 +10,7 @@ declare module "electron-osx-sign" {
     binaries?: string[];
     entitlements?: string;
     'entitlements-inherit'?: string;
+    'entitlements-loginhelper'?: string;
     'gatekeeper-assess'?: boolean;
     hardenedRuntime?: boolean;
     'identity-validation'?: boolean;

--- a/sign.js
+++ b/sign.js
@@ -333,11 +333,12 @@ var signAsync = module.exports.signAsync = function (opts) {
         if (!opts['entitlements-inherit']) {
           filePath = path.join(__dirname, 'default.entitlements.mas.inherit.plist')
           debugwarn('No `entitlements-inherit` passed in arguments:', '\n',
-            '* Sandbox entitlements file for enclosing app files is default to:', filePath)
+            '* Sandbox entitlements file for enclosed app files is default to:', filePath)
           opts['entitlements-inherit'] = filePath
         }
         if (!opts['entitlements-loginhelper']) {
-          filePath = path.join(__dirname, 'default.entitlements.mas.inherit.plist')
+          // Default to App Sandbox enabled
+          filePath = path.join(__dirname, 'default.entitlements.mas.plist')
           debugwarn('No `entitlements-loginhelper` passed in arguments:', '\n',
             '* Sandbox entitlements file for login helper is default to:', filePath)
           opts['entitlements-loginhelper'] = filePath
@@ -348,24 +349,25 @@ var signAsync = module.exports.signAsync = function (opts) {
           debugwarn('No `entitlements` passed in arguments:', '\n',
             '* Provide `entitlements` to specify entitlements file for codesign.')
         } else {
-          // If entitlements is provided as a flag, fallback to default
+          // If entitlements is provided as a boolean flag, fallback to default
           if (opts.entitlements === true) {
             filePath = path.join(__dirname, 'default.entitlements.darwin.plist')
             debugwarn('`entitlements` not specified in arguments:', '\n',
               '* Provide `entitlements` to specify entitlements file for codesign.', '\n',
-              '* Sandbox entitlements file for enclosing app files is default to:', filePath)
+              '* Entitlements file is default to:', filePath)
             opts.entitlements = filePath
           }
           if (!opts['entitlements-inherit']) {
             filePath = path.join(__dirname, 'default.entitlements.darwin.inherit.plist')
             debugwarn('No `entitlements-inherit` passed in arguments:', '\n',
-              '* Sandbox entitlements file for enclosing app files is default to:', filePath)
+              '* Entitlements file for enclosed app files is default to:', filePath)
             opts['entitlements-inherit'] = filePath
           }
           if (!opts['entitlements-loginhelper']) {
-            filePath = path.join(__dirname, 'default.entitlements.darwin.inherit.plist')
+            // Default to App Sandbox enabled
+            filePath = path.join(__dirname, 'default.entitlements.mas.plist')
             debugwarn('No `entitlements-loginhelper` passed in arguments:', '\n',
-              '* Sandbox entitlements file for enclosing app files is default to:', filePath)
+              '* Entitlements file for login helper is default to:', filePath)
             opts['entitlements-loginhelper'] = filePath
           }
         }

--- a/sign.js
+++ b/sign.js
@@ -206,7 +206,13 @@ function signApplicationAsync (opts) {
             return
           }
           debuglog('Signing... ' + filePath)
-          return execFileAsync('codesign', args.concat('--entitlements', opts['entitlements-inherit'], filePath))
+
+          let entitlementsFile = opts['entitlements-inherit'];
+          if (filePath.includes('Library/LoginItems')) {
+            entitlementsFile = opts['entitlements-loginhelper'];
+          }
+
+          return execFileAsync('codesign', args.concat('--entitlements', entitlementsFile, filePath))
         })
           .then(function () {
             debuglog('Signing... ' + opts.app)
@@ -330,6 +336,12 @@ var signAsync = module.exports.signAsync = function (opts) {
             '* Sandbox entitlements file for enclosing app files is default to:', filePath)
           opts['entitlements-inherit'] = filePath
         }
+        if (!opts['entitlements-loginhelper']) {
+          filePath = path.join(__dirname, 'default.entitlements.mas.inherit.plist')
+          debugwarn('No `entitlements-loginhelper` passed in arguments:', '\n',
+            '* Sandbox entitlements file for login helper is default to:', filePath)
+          opts['entitlements-loginhelper'] = filePath
+        }
       } else {
         // Not necessary to have entitlements for non Mac App Store distribution
         if (!opts.entitlements) {
@@ -349,6 +361,12 @@ var signAsync = module.exports.signAsync = function (opts) {
             debugwarn('No `entitlements-inherit` passed in arguments:', '\n',
               '* Sandbox entitlements file for enclosing app files is default to:', filePath)
             opts['entitlements-inherit'] = filePath
+          }
+          if (!opts['entitlements-loginhelper']) {
+            filePath = path.join(__dirname, 'default.entitlements.darwin.inherit.plist')
+            debugwarn('No `entitlements-loginhelper` passed in arguments:', '\n',
+              '* Sandbox entitlements file for enclosing app files is default to:', filePath)
+            opts['entitlements-loginhelper'] = filePath
           }
         }
       }
@@ -387,6 +405,7 @@ var signAsync = module.exports.signAsync = function (opts) {
         '> Platform:', opts.platform, '\n',
         '> Entitlements:', opts.entitlements, '\n',
         '> Child entitlements:', opts['entitlements-inherit'], '\n',
+        '> Login helper entitlement:', opts['entitlements-loginhelper'], '\n',
         '> Additional binaries:', opts.binaries, '\n',
         '> Identity:', opts.identity)
       return signApplicationAsync(opts)

--- a/sign.js
+++ b/sign.js
@@ -207,9 +207,9 @@ function signApplicationAsync (opts) {
           }
           debuglog('Signing... ' + filePath)
 
-          let entitlementsFile = opts['entitlements-inherit'];
+          let entitlementsFile = opts['entitlements-inherit']
           if (filePath.includes('Library/LoginItems')) {
-            entitlementsFile = opts['entitlements-loginhelper'];
+            entitlementsFile = opts['entitlements-loginhelper']
           }
 
           return execFileAsync('codesign', args.concat('--entitlements', entitlementsFile, filePath))


### PR DESCRIPTION
When signing the electron app for App Store, the Login Helper is signed child inherited entitlements. Since the Login Helper is a standalone executable, it crashes on because it shouldn't have the `com.apple.security.inherit`.

This PR adds an option to specify a custom entitlement file for the login helper.