### PR TITLE
fix: Don't publish test files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+/test
+/yarn.lock
+/.*


### PR DESCRIPTION
This PR will prevent npm from publishing the test files, the yarn lock file and the CircleCI config file.