### PR TITLE
feat: added keychain arg to GetProvisioningProfileAsync

### DIFF
--- a/util-provisioning-profiles.js
+++ b/util-provisioning-profiles.js
@@ -62,12 +62,12 @@ var getProvisioningProfileAsync = module.exports.getProvisioningProfileAsync = f
     'cms',
     '-D', // Decode a CMS message
     '-i', filePath // Use infile as source of data
-  ];
+  ]
 
   if (keychain) {
-    securityArgs.push('-k', keychain);
+    securityArgs.push('-k', keychain)
   }
-  
+
   return execFileAsync('security', securityArgs)
     .then(function (result) {
       var provisioningProfile = new ProvisioningProfile(filePath, plist.parse(result))

--- a/util-provisioning-profiles.js
+++ b/util-provisioning-profiles.js
@@ -54,14 +54,21 @@ Object.defineProperty(ProvisioningProfile.prototype, 'type', {
  * Returns a promise resolving to a ProvisioningProfile instance based on file.
  * @function
  * @param {string} filePath - Path to provisioning profile.
+ * @param {string} keychain - Keychain to use when unlocking provisioning profile.
  * @returns {Promise} Promise.
  */
-var getProvisioningProfileAsync = module.exports.getProvisioningProfileAsync = function (filePath) {
-  return execFileAsync('security', [
+var getProvisioningProfileAsync = module.exports.getProvisioningProfileAsync = function (filePath, keychain = null) {
+  var securityArgs = [
     'cms',
     '-D', // Decode a CMS message
     '-i', filePath // Use infile as source of data
-  ])
+  ];
+
+  if (keychain) {
+    securityArgs.push('-k', keychain);
+  }
+  
+  return execFileAsync('security', securityArgs)
     .then(function (result) {
       var provisioningProfile = new ProvisioningProfile(filePath, plist.parse(result))
       debuglog('Provisioning profile:', '\n',
@@ -144,7 +151,7 @@ module.exports.preEmbedProvisioningProfile = function (opts) {
     if (opts['provisioning-profile'] instanceof ProvisioningProfile) {
       return embedProvisioningProfile()
     } else {
-      return getProvisioningProfileAsync(opts['provisioning-profile'])
+      return getProvisioningProfileAsync(opts['provisioning-profile'], opts['keychain'])
         .then(function (provisioningProfile) {
           opts['provisioning-profile'] = provisioningProfile
         })


### PR DESCRIPTION
## What is this PR fixing?
Fixes (#206) - When the command `security cms` runs, it will default to system keychains during a bamboo build even if a keychain is passed in using the CSC_KEYCHAIN environment variable.

## What has changed?
Inside of getProvisioningProfileAsync function (found within electron-osx-sign package) I added a keychain arg to surface the CSC_KEYCHAIN environment variable as a flag to the `security` command.

### How to test?
This is best reproduced on a bamboo build agent machine. If you do not have a bamboo server to test with, follow these instructions:
1) Toggle debug mode for electron osx sign `debug=electron-osx-sign` 
2) set `CSC_KEYCHAIN` environment variable
3) build and ensure that during the signing process that the correct keychain file is being used (instead of login or system keychain)

### Notes
1) This is my first contribution to this repo. If I've done anything wrong please let me know I will fix :p
