### PR TITLE
fix: add ts type for hardenedRuntime option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -11,6 +11,7 @@ declare module "electron-osx-sign" {
     entitlements?: string;
     'entitlements-inherit'?: string;
     'gatekeeper-assess'?: boolean;
+    hardenedRuntime?: boolean;
     ignore?: string;
     'pre-auto-entitlements'?: boolean;
     'pre-embed-provisioning-profile'?: boolean;


### PR DESCRIPTION
This adds a TypeScript type for the optional `hardenedRuntime` option.

(Ran into this in https://github.com/desktop/desktop/pull/8555)