### PR TITLE
fix: sign child paths in order of depth

### DIFF
--- a/sign.js
+++ b/sign.js
@@ -198,6 +198,16 @@ function signApplicationAsync (opts) {
       }
 
       var promise
+      /**
+       * Sort the child paths by how deep they are in the file tree.  Some arcane apple
+       * logic expects the deeper files to be signed first otherwise strange errors get
+       * thrown our way
+       */
+      childPaths = childPaths.sort((a, b) => {
+        const aDepth = a.split(path.sep).length
+        const bDepth = b.split(path.sep).length
+        return bDepth - aDepth
+      })
       if (opts.entitlements) {
         // Sign with entitlements
         promise = Promise.mapSeries(childPaths, function (filePath) {


### PR DESCRIPTION
Well this is silly, but hey, 🤷‍♂️ 

Fixes https://github.com/electron/electron/issues/23534