### PR TITLE
feat: Support Apple Development/Distribution identities

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,9 +181,10 @@ macOS >= 10.13.6.
 `identity` - *String*
 
 Name of certificate to use when signing.
-Default to be selected with respect to `provisioning-profile` and `platform` from `keychain` or keychain by system default.
+Default to be auto-discovered in the specified `keychain` or the keychain by system default with respect to `type` and `platform`.
 
-Signing platform `mas` will look for `3rd Party Mac Developer Application: * (*)`, and platform `darwin` will look for `Developer ID Application: * (*)` by default.
+For development: Signing for platform `mas` will look for `Apple Development: * (*)` then `Mac Developer: * (*)`, and signing for platform `darwin` will look for `Developer ID Application: * (*)` by default.
+For distribution: Signing for platform `mas` will look for `Apple Distribution: * (*)` then `3rd Party Mac Developer Application: * (*)`, and signing for platform `darwin` will look for `Developer ID Application: * (*)` by default.
 
 `identity-validation` - *Boolean*
 
@@ -344,9 +345,9 @@ Needs file extension `.app`.
 `identity` - *String*
 
 Name of certificate to use when signing.
-Default to be selected with respect to `platform` from `keychain` or keychain by system default.
+Default to be auto-discovered in the specified `keychain` or the keychain by system default with respect to `platform`.
 
-Flattening platform `mas` will look for `3rd Party Mac Developer Installer: * (*)`, and platform `darwin` will look for `Developer ID Installer: * (*)` by default.
+Flattening for platform `mas` will look for `3rd Party Mac Developer Installer: * (*)`, and flattening for platform `darwin` will look for `Developer ID Installer: * (*)` by default.
 
 `identity-validation` - *Boolean*
 
@@ -388,7 +389,7 @@ As of release v0.3.1, external module `debug` is used to display logs and messag
 
 The project's configured to run automated tests on CircleCI.
 
-If you wish to manually test the module, first comment out `opts.identity` in `test/basic.js` to enable auto discovery. Then run the command `npm test` from the dev directory.
+If you wish to manually test the module, first comment out `opts.identity` in `test/basic.js` to enable auto-discovery. Then run the command `npm test` from the dev directory.
 
 When this command is run for the first time: `electron-download` will download macOS Electron releases defined in `test/config.json`, and save to `~/.electron/`, which might take up less than 1GB of disk space.
 

--- a/bin/electron-osx-flat-usage.txt
+++ b/bin/electron-osx-flat-usage.txt
@@ -15,7 +15,7 @@ DESCRIPTION
 
   --identity=identity
     Name of certificate to use when signing.
-    Default to selected with respect to --platform from --keychain specified or keychain by system default.
+    Default to be auto-discovered in the specified --keychain or the keychain by system default with respect to --platform.
 
   --identity-validation, --no-identity-validation
     Flag to enable/disable validation for the signing identity.

--- a/bin/electron-osx-sign-usage.txt
+++ b/bin/electron-osx-sign-usage.txt
@@ -38,7 +38,7 @@ DESCRIPTION
 
   --identity=identity
     Name of certificate to use when signing.
-    Default to selected with respect to --provisioning-profile and --platform from --keychain specified or keychain by system default.
+    Default to be auto-discovered in the specified --keychain or the keychain by system default with respect to --type and --platform.
 
   --identity-validation, --no-identity-validation
     Flag to enable/disable validation for the signing identity.

--- a/flat.js
+++ b/flat.js
@@ -15,7 +15,7 @@ const debugwarn = util.debugwarn
 const execFileAsync = util.execFileAsync
 const validateOptsAppAsync = util.validateOptsAppAsync
 const validateOptsPlatformAsync = util.validateOptsPlatformAsync
-const Identity = require('./util-identities').findIdentitiesAsync
+const Identity = require('./util-identities').Identity
 const findIdentitiesAsync = require('./util-identities').findIdentitiesAsync
 
 /**

--- a/sign.js
+++ b/sign.js
@@ -300,11 +300,11 @@ var signAsync = module.exports.signAsync = function (opts) {
         debugwarn('No `identity` passed in arguments...')
         if (opts.platform === 'mas') {
           if (opts.type === 'distribution') {
-            debuglog('Finding `3rd Party Mac Developer Application` certificate for signing app distribution in the Mac App Store...')
-            promise = findIdentitiesAsync(opts, '3rd Party Mac Developer Application:')
+            debuglog('Finding `Apple Distribution` or `3rd Party Mac Developer Application` certificate for signing app distribution in the Mac App Store...')
+            promise = findIdentitiesAsync(opts, ['Apple Distribution:', '3rd Party Mac Developer Application:'])
           } else {
-            debuglog('Finding `Mac Developer` certificate for signing app in development for the Mac App Store signing...')
-            promise = findIdentitiesAsync(opts, 'Mac Developer:')
+            debuglog('Finding `Apple Development` or `Mac Developer` certificate for signing app in development for the Mac App Store signing...')
+            promise = findIdentitiesAsync(opts, ['Apple Development:', 'Mac Developer:'])
           }
         } else {
           debuglog('Finding `Developer ID Application` certificate for distribution outside the Mac App Store...')


### PR DESCRIPTION
Follow up to the feature request https://github.com/electron/electron-osx-sign/issues/227

Following the introduction of "Apple Development" and "Apple Distribution" signing identities, we can extend the existing auto-discovery to support these identities:

- Targeting inside the Mac App Store
  - For development: Try `Apple Development`, then `Mac Developer`
  - For distribution: Try `Apple Distribution`, then `3rd Party Mac Developer Application`
- Targeting outside the Mac App Store
  - Always try `Developer ID Application` for development/distribution

Closing https://github.com/electron/electron-osx-sign/pull/183 for now, since there isn't much complain using `Developer ID Application` for both development and distribution of apps outside the Mac App Store.