### PR TITLE
Fix issue with spaces in the app name

### DIFF
--- a/sign.js
+++ b/sign.js
@@ -287,6 +287,7 @@ var signAsync = module.exports.signAsync = function (opts) {
     .then(function () {
       // Determine identity for signing
       var promise
+      opts.app.replace(' ', '\ ')
       if (opts.identity) {
         debuglog('`identity` passed in arguments.')
         if (opts['identity-validation'] === false) {


### PR DESCRIPTION
I created an issue: https://github.com/electron/electron-osx-sign/issues/237

I believe this was caused by not having the escape character when the codesign command string was being constructed; therefore, causing the codesign command to fail when codesigning the executable e.g. `App name.app/Contents/MacOS/App name`

I was able to successfully codesign with electron-osx-sign with the change.  I hope this resolves issues that others may have run into because their electron app product name has spaces.